### PR TITLE
refactor: don't use temporary field

### DIFF
--- a/Classes/GroupFinder.py
+++ b/Classes/GroupFinder.py
@@ -6,18 +6,18 @@ from configs.config import rozklad_list, rozklad_domen, export_directory
 class GroupFinder:
     __json_name = 'group_links'
     __soup = Responser.get_soup(rozklad_list)
-    __dictionary = {}
 
     def __get_groups(self):
+        groups = {}
         for group in self.__soup.find('div', class_='accordion-item').find_all('a'):
-            self.__dictionary[group.text] = f'{rozklad_domen}{group.get('href')}'
-
-        BuilderJSON.create(self.__dictionary, self.__json_name)
+            groups[group.text] = f'{rozklad_domen}{group.get('href')}'
+        return groups
 
     def find(self, name_group):
         if FileManager.check_time(f'{export_directory}{self.__json_name}.json'):
-            self.__get_groups()
+            groups = self.__get_groups()
             print(f'File {export_directory}{self.__json_name}.json recreate')
+            BuilderJSON.create(groups, self.__json_name)
 
         try:
             return BuilderJSON.get(self.__json_name)[name_group]


### PR DESCRIPTION
Turns `__get_groups` into a function that returns data instead of writing to the disk 
Closes #18